### PR TITLE
Escape newline breaks in string

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -85,6 +85,7 @@ export default class GoogleOAuth {
         const buf = this.str2ab(content)
         const plainKey = signingKey
             .replace(/(\r\n|\n|\r)/gm, '')
+            .replace(/\\n/g, '')
             .replace(PEM_HEADER, '')
             .replace(PEM_FOOTER, '')
             .trim()


### PR DESCRIPTION
My JSON stringified service account contained escaped new lines, so the replace regex didn't match them. This change handles that case.